### PR TITLE
Changed `peerDependencies` to `dependencies`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+# VHX Eslint Config

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vhx/eslint-config-vhx",
-  "version": "0.0.3",
+  "version": "0.0.2",
   "description": "VHX Shared Eslint Config",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,18 +1,19 @@
 {
   "name": "@vhx/eslint-config-vhx",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "description": "VHX Shared Eslint Config",
   "main": "index.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/vhx/eslint-config-vhx.git"
   },
-  "peerDependencies": {
+  "dependencies": {
     "eslint": ">= 3",
     "eslint-config-airbnb": ">= 15",
+    "eslint-plugin-babel": ">= 4",
+    "eslint-plugin-import": ">= 2",
     "eslint-plugin-react": ">= 7",
-    "eslint-plugin-jsx-a11y": ">= 5",
-    "eslint-plugin-import": ">= 2"
+    "eslint-plugin-jsx-a11y": ">= 5"
   },
   "keywords": [
     "eslint",


### PR DESCRIPTION
Changed `peerDependencies` to `dependencies` since these dependencies do need to be installed for the linting to work, and `peerDependencies` do not automatically get installed (which is less convenient).